### PR TITLE
Add a dynamic custom type collection

### DIFF
--- a/src/BestItCTCustomTypesBundle.php
+++ b/src/BestItCTCustomTypesBundle.php
@@ -2,6 +2,8 @@
 
 namespace BestIt\CTCustomTypesBundle;
 
+use BestIt\CTCustomTypesBundle\DependencyInjection\Compiler\CollectionCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -12,5 +14,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class BestItCTCustomTypesBundle extends Bundle
 {
-
+    /**
+     * @inheritdoc
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new CollectionCompilerPass());
+    }
 }

--- a/src/Collection/CustomTypeCollection.php
+++ b/src/Collection/CustomTypeCollection.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace BestIt\CTCustomTypesBundle\Collection;
+
+use ArrayAccess;
+use BestIt\CTCustomTypesBundle\Model\CustomTypeResource;
+
+/**
+ * Provide a collection for custom type keys
+ * @author chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CTCustomTypesBundle
+ * @subpackage Collection
+ * @version $id$
+ */
+class CustomTypeCollection implements ArrayAccess
+{
+    /**
+     * The collection
+     * @var CustomTypeResource[]
+     */
+    private $collection = [];
+
+    /**
+     * Get all keys
+     * @return CustomTypeResource[]
+     */
+    public function all(): array
+    {
+        return $this->collection;
+    }
+
+    /**
+     * Clears all keys
+     * @return CustomTypeCollection
+     */
+    public function clear(): CustomTypeCollection
+    {
+        $this->collection = [];
+
+        return $this;
+    }
+
+    /**
+     * Get specific array of keys of given type name
+     * @param string $name
+     * @return CustomTypeResource|null
+     */
+    public function get(string $name): CustomTypeResource
+    {
+        $result = null;
+
+        if ($this->has($name)) {
+            $result = $this->collection[$name];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if given key name exists
+     * @param string $name
+     * @return bool
+     */
+    public function has(string $name): bool
+    {
+        return array_key_exists(strtolower($name), $this->collection);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetExists($offset)
+    {
+        return $this->has($offset);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->collection[] = $value;
+        } else {
+            $this->set($offset, $value);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetUnset($offset)
+    {
+        $this->remove($offset);
+    }
+
+    /**
+     * Removes a key value pair
+     * @param string $name
+     * @return CustomTypeCollection
+     */
+    public function remove(string $name): CustomTypeCollection
+    {
+        unset($this->collection[strtolower($name)]);
+
+        return $this;
+    }
+
+    /**
+     * Add a key value pair
+     * @param string $name
+     * @param CustomTypeResource $value
+     * @return CustomTypeCollection
+     */
+    public function set(string $name, CustomTypeResource $value): CustomTypeCollection
+    {
+        $this->collection[strtolower($name)] = $value;
+
+        return $this;
+    }
+
+    /**
+     * This will add one key into a custom type resource.
+     * If the custom type resource not exists, we'll generate one
+     * @param string $name
+     * @param string $key
+     * @return CustomTypeCollection
+     */
+    public function add(string $name, string $key): CustomTypeCollection
+    {
+        if (!$this->has($name)) {
+            $this->collection[$name] = new CustomTypeResource($name);
+        }
+
+        $this->collection[$name][] = $key;
+
+        return $this;
+    }
+}

--- a/src/DependencyInjection/BestItCTCustomTypesExtension.php
+++ b/src/DependencyInjection/BestItCTCustomTypesExtension.php
@@ -2,7 +2,9 @@
 
 namespace BestIt\CTCustomTypesBundle\DependencyInjection;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -15,10 +17,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class BestItCTCustomTypesExtension extends Extension
 {
     /**
-     * Loads the bundle config.
-     * @param array $configs
-     * @param ContainerBuilder $container
-     * @return void
+     * @inheritdoc
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -27,5 +26,8 @@ class BestItCTCustomTypesExtension extends Extension
         $container->setAlias('best_it_ct_custom_types.client', $config['commercetools_client_service']);
         $container->setParameter('best_it_ct_custom_types.types', $config['types'] ?? []);
         $container->setParameter('best_it_ct_custom_types.whitelist', $config['whitelist'] ?? []);
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
     }
 }

--- a/src/DependencyInjection/Compiler/CollectionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CollectionCompilerPass.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BestIt\CTCustomTypesBundle\DependencyInjection\Compiler;
+
+use BestIt\CTCustomTypesBundle\Model\CustomTypeResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Collect all custom types into collection
+ * @author chowanski <michel.chowanski@bestit-online.de>
+ * @package BestIt\CTCustomTypesBundle\DependencyInjection\Compiler
+ * @version $id$
+ */
+class CollectionCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('best_it.ct_custom_types.collection.custom_type_collection')) {
+            $definition = $container->getDefinition('best_it.ct_custom_types.collection.custom_type_collection');
+
+            /*
+             * We don't want to set custom type keys twice (in custom type yml and in config yml)
+             * So we detect all resource type id from our current custom type yml and set a key value pair
+             * resource => type key
+             * Eg. "order" =>   [
+             *                      "bh-cart",
+             *                      "bj-custom-cart",
+             *                      "cart-nk"
+             *                  ]
+             */
+            if ($customTypes = $container->getParameter('best_it_ct_custom_types.types')) {
+                foreach ($customTypes as $name => $type) {
+                    foreach ($type['resourceTypeIds'] as $resourceTypeId) {
+                        $definition->addMethodCall('add', [$resourceTypeId, $name]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Enum/ResourceType.php
+++ b/src/Enum/ResourceType.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BestIt\CTCustomTypesBundle\Enum;
+
+use ReflectionClass;
+
+/**
+ * Enum for available resource types
+ * @author chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CTCustomTypesBundle
+ * @subpackage Enum
+ * @version $id$
+ */
+class ResourceType
+{
+    /**
+     * Asset
+     * @var string
+     */
+    const ASSET = 'asset';
+
+    /**
+     * Category
+     * @var string
+     */
+    const CATEGORY = 'category';
+
+    /**
+     * Channel
+     * @var string
+     */
+    const CHANNEL = 'channel';
+
+    /**
+     * Customer
+     * @var string
+     */
+    const CUSTOMER = 'customer';
+
+    /**
+     * Cart and Order
+     * @var string
+     */
+    const ORDER = 'order';
+
+    /**
+     * Line item
+     * @var string
+     */
+    const LINE_ITEM = 'line-item';
+
+    /**
+     * Custom line item
+     * @var string
+     */
+    const CUSTOM_LINE_ITEM = 'custom-line-item';
+
+    /**
+     * Product price
+     * @var string
+     */
+    const PRODUCT_PRICE = 'product-price';
+
+    /**
+     * Payment
+     * @var string
+     */
+    const PAYMENT = 'payment';
+
+    /**
+     * Payment interface interaction
+     * @var string
+     */
+    const PAYMENT_INTERFACE_INTERACTION = 'payment-interface-interaction';
+
+    /**
+     * Shopping list
+     * @var string
+     */
+    const SHOPPING_LIST = 'shopping-list';
+
+    /**
+     * Shopping list text line item
+     * @var string
+     */
+    const SHOPPING_LIST_TEXT_LINE_ITEM = 'shopping-list-text-line-item';
+
+    /**
+     * Review
+     * @var string
+     */
+    const REVIEW = 'review';
+
+    /**
+     * Check if given value is a valid enum type
+     * @param string $key
+     * @return bool
+     */
+    public static function isValid(string $key): bool
+    {
+        $types = (new ReflectionClass(__CLASS__))->getConstants();
+
+        return in_array($key, $types, true);
+    }
+}

--- a/src/Model/CustomTypeResource.php
+++ b/src/Model/CustomTypeResource.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace BestIt\CTCustomTypesBundle\Model;
+
+use ArrayAccess;
+
+/**
+ * Model which contains the custom types keys for one ResourceType
+ * @author chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CTCustomTypesBundle
+ * @subpackage Model
+ * @version $id$
+ */
+class CustomTypeResource implements ArrayAccess
+{
+    /**
+     * The collection
+     * @var array
+     */
+    private $collection = [];
+
+    /**
+     * The unique resource name
+     * @var string
+     */
+    private $name;
+
+    /**
+     * CustomTypeResource constructor
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->setName($name);
+    }
+
+    /**
+     * Get all keys
+     * @return array
+     */
+    public function all(): array
+    {
+        return $this->collection;
+    }
+
+    /**
+     * Find one (first) key of resource
+     * @return string|null
+     */
+    public function findOne()
+    {
+        return $this->offsetGet(0);
+    }
+
+    /**
+     * Get name
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->collection[$offset]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetGet($offset)
+    {
+        return $this->offsetExists($offset) ? $this->collection[$offset] : null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->collection[] = $value;
+        } else {
+            $this->collection[$offset][] = $value;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->collection[$offset]);
+    }
+
+    /**
+     * Set name
+     * @param string $name
+     * @return CustomTypeResource
+     */
+    public function setName(string $name): CustomTypeResource
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,0 +1,3 @@
+services:
+    best_it.ct_custom_types.collection.custom_type_collection:
+        class: BestIt\CTCustomTypesBundle\Collection\CustomTypeCollection


### PR DESCRIPTION
Im Projekt werden zum Teil die definierten Keys benötigt. Damit ich diese in der config.yml nicht zusätzlich und somit doppelt definieren muss, habe ich diese entsprechenden Erweiterungen hinzugefügt.

Die Collection sammelt alle definierten custom types keys und speichert diese ab - so dass ich später in den Servcies mit der Resource (zb. "order") den Key Namen erhalte. Die Ressourcen sind von CT fest definiert, daher eignen diese sich zum suchen.
Alle derzeit verfügbaren Resourcen (laut Doku) sind auch in der ResourceType Enum zur Verfügung gestellt worden.